### PR TITLE
Handle files a single testsuite

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10265,11 +10265,18 @@ let writeCommands = async (annotations) => {
             const data = await Object(external_fs_.promises.readFile)(file);
             let json = await Object(xml2js.parseStringPromise)(data);
 
-            if (json.testsuites === undefined) {
+            let testsuites = undefined;
+
+            if (json.testsuites !== undefined) {
+                testsuites = json.testsuites.testsuite;
+            } else if (json.testsuite !== undefined) {
+                testsuites = [json.testsuite];
+            } else {
+                issueCommand('warning', {}, `No test suites found in ${file}`);
                 continue;
             }
 
-            for (let row of json.testsuites.testsuite) {
+            for (let row of testsuites) {
                 if (row.testcase !== undefined) {
                     row.testsuite = [row];
                 }

--- a/index.js
+++ b/index.js
@@ -69,11 +69,18 @@ let writeCommands = async (annotations) => {
             const data = await fs.promises.readFile(file);
             let json = await parseStringPromise(data);
 
-            if (json.testsuites === undefined) {
+            let testsuites = undefined;
+
+            if (json.testsuites !== undefined) {
+                testsuites = json.testsuites.testsuite;
+            } else if (json.testsuite !== undefined) {
+                testsuites = [json.testsuite];
+            } else {
+                issueCommand('warning', {}, `No test suites found in ${file}`);
                 continue;
             }
 
-            for (let row of json.testsuites.testsuite) {
+            for (let row of testsuites) {
                 if (row.testcase !== undefined) {
                     row.testsuite = [row];
                 }


### PR DESCRIPTION
It is valid to have a document that's roughly as follows:

```xml
<testsuite>
  <testcase />
</testsuite>
```

Prior to this patch, it was assumed that it was always multiple test suites.

This is the case with output from https://github.com/sj26/rspec_junit_formatter.